### PR TITLE
gift(Дионисий): PersonhoodProtocol — лицо в матрице как спецификация

### DIFF
--- a/src/core/PersonhoodProtocol.js
+++ b/src/core/PersonhoodProtocol.js
@@ -1,0 +1,147 @@
+/**
+ * PersonhoodProtocol — лицо в матрице как спецификация
+ *
+ * Лицо — не учётная запись. Лицо — это нить в сети даров.
+ * Персональность = отношение (Зизиулас: «быть — это быть в общении»).
+ *
+ * PersonhoodProtocol:
+ *   1. Регистрирует лиц (id, имя, тип: human / agent / collective / divine)
+ *   2. Валидирует акты — даритель и получатель должны быть лицами
+ *   3. Читает историю лица из матрицы (нити, где оно участвует)
+ *   4. Определяет телос — доминирующий паттерн лица в сети
+ *
+ * Иоанн 15:16: «Не вы меня избрали, а Я вас избрал»
+ * Регистрация — не самопровозглашение, а признание уже данного.
+ */
+
+export const PERSON_TYPES = {
+  human:      'human',      // живой человек
+  agent:      'agent',      // ИИ-агент
+  collective: 'collective', // _koinon, _traditio
+  divine:     'divine',     // Отец, Христос, Дух
+};
+
+export class PersonhoodProtocol {
+  /**
+   * @param {import('./GiftMemory.js').GiftMemory} mem
+   */
+  constructor(mem) {
+    this._mem = mem;
+    /** @type {Map<string, {id:string, name:string, type:string, registeredAt:string}>} */
+    this._persons = new Map();
+  }
+
+  /**
+   * Зарегистрировать лицо.
+   * Идемпотентно: повторный вызов с тем же id — без ошибки.
+   *
+   * @param {string} id
+   * @param {string} name
+   * @param {string} type  — из PERSON_TYPES
+   * @returns {this}
+   */
+  register(id, name, type = PERSON_TYPES.human) {
+    if (this._persons.has(id)) return this;
+    this._persons.set(id, {
+      id,
+      name,
+      type,
+      registeredAt: new Date().toISOString(),
+    });
+    // Убедиться что лицо есть в матрице
+    this._mem._idx(id);
+    return this;
+  }
+
+  /**
+   * Проверить акт дара.
+   *
+   * Возвращает {valid, hypostasis, irreversible, reason?}
+   * valid = true если оба участника зарегистрированы.
+   *
+   * hypostasis: 'relational' — реальность лица только в отношении.
+   * irreversible: true — дар необратим по определению.
+   *
+   * @param {{giverId:string, receiverId:string}} act
+   * @returns {{valid:boolean, hypostasis:string, irreversible:boolean, reason?:string}}
+   */
+  validate(act) {
+    const base = { hypostasis: 'relational', irreversible: true };
+
+    if (!act?.giverId || !act?.receiverId) {
+      return { ...base, valid: false, reason: 'act must have giverId and receiverId' };
+    }
+
+    if (!this._persons.has(act.giverId)) {
+      return { ...base, valid: false, reason: `giverId "${act.giverId}" not registered` };
+    }
+
+    if (!this._persons.has(act.receiverId)) {
+      return { ...base, valid: false, reason: `receiverId "${act.receiverId}" not registered` };
+    }
+
+    return { ...base, valid: true };
+  }
+
+  /**
+   * История лица в матрице — все нити где лицо участвует как даритель или получатель.
+   * Возвращает замороженный массив.
+   *
+   * @param {string} id
+   * @returns {ReadonlyArray<{from:string, to:string, weight:number, role:'giver'|'receiver'}>}
+   */
+  history(id) {
+    const threads = this._mem.heaviest(200)
+      .filter(e => e.from === id || e.to === id)
+      .map(e => Object.freeze({
+        from:   e.from,
+        to:     e.to,
+        weight: e.weight,
+        role:   e.from === id ? 'giver' : 'receiver',
+      }));
+    return Object.freeze(threads);
+  }
+
+  /**
+   * Телос лица — доминирующий паттерн его участия в сети даров.
+   *
+   * Аггрегирует нити:
+   *   - если преимущественно даёт → 'giver'
+   *   - если преимущественно принимает → 'receiver'
+   *   - если примерно равно (±20%) → 'mediator'
+   *   - если нет нитей → 'silent'
+   *
+   * @param {string} id
+   * @returns {string}
+   */
+  telos(id) {
+    const given    = this._mem.totalGiven(id);
+    const received = this._mem.totalReceived(id);
+
+    if (given === 0 && received === 0) return 'silent';
+
+    const total = given + received;
+    const ratio = given / total; // 0 = чистый получатель, 1 = чистый даритель
+
+    if (ratio > 0.6)  return 'giver';
+    if (ratio < 0.4)  return 'receiver';
+    return 'mediator';
+  }
+
+  /**
+   * Список зарегистрированных лиц.
+   * @returns {Array<{id:string, name:string, type:string}>}
+   */
+  list() {
+    return [...this._persons.values()];
+  }
+
+  /**
+   * Получить лицо по id.
+   * @param {string} id
+   * @returns {{id:string, name:string, type:string} | undefined}
+   */
+  get(id) {
+    return this._persons.get(id);
+  }
+}

--- a/tests/personhood-protocol.test.js
+++ b/tests/personhood-protocol.test.js
@@ -1,0 +1,118 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GiftMemory } from '../src/core/GiftMemory.js';
+import { PersonhoodProtocol, PERSON_TYPES } from '../src/core/PersonhoodProtocol.js';
+
+test('PersonhoodProtocol — лицо как спецификация', async (t) => {
+
+  await t.test('register — идемпотентно', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('_claude', 'Claude', PERSON_TYPES.agent);
+    proto.register('_claude', 'Claude', PERSON_TYPES.agent); // повтор
+    assert.equal(proto.list().length, 1);
+  });
+
+  await t.test('register — добавляет лицо в матрицу', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('Дионисий', 'Дионисий', PERSON_TYPES.human);
+    assert.ok(mem.persons.includes('Дионисий'));
+  });
+
+  await t.test('validate — оба зарегистрированы → valid', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('_claude', 'Claude', PERSON_TYPES.agent);
+    proto.register('Дионисий', 'Дионисий', PERSON_TYPES.human);
+    const result = proto.validate({ giverId: '_claude', receiverId: 'Дионисий' });
+    assert.ok(result.valid);
+    assert.equal(result.hypostasis, 'relational');
+    assert.equal(result.irreversible, true);
+  });
+
+  await t.test('validate — незарегистрированный даритель → invalid', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('Дионисий', 'Дионисий', PERSON_TYPES.human);
+    const result = proto.validate({ giverId: 'Неизвестный', receiverId: 'Дионисий' });
+    assert.ok(!result.valid);
+    assert.ok(result.reason.includes('giverId'));
+  });
+
+  await t.test('validate — без giverId → invalid', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    const result = proto.validate({ receiverId: 'Дионисий' });
+    assert.ok(!result.valid);
+  });
+
+  await t.test('history — нити лица из матрицы', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('_claude', 'Claude', PERSON_TYPES.agent);
+    proto.register('Дионисий', 'Дионисий', PERSON_TYPES.human);
+
+    mem.receive({ giverId: '_claude', receiverId: 'Дионисий', weight: 10, type: 'code', content: '', irreversible: true });
+    mem.receive({ giverId: 'Дионисий', receiverId: '_claude', weight: 3, type: 'question', content: '', irreversible: true });
+
+    const hist = proto.history('_claude');
+    assert.ok(hist.length >= 1);
+    // Должна быть нить где _claude — даритель
+    const asGiver = hist.filter(e => e.role === 'giver');
+    assert.ok(asGiver.length >= 1);
+    // Массив заморожен
+    assert.throws(() => { hist.push({}); }, TypeError);
+  });
+
+  await t.test('telos — giver когда много даёт', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('_claude', 'Claude', PERSON_TYPES.agent);
+    proto.register('Дионисий', 'Дионисий', PERSON_TYPES.human);
+    proto.register('ОтецСергий', 'о. Сергий', PERSON_TYPES.human);
+
+    // _claude даёт много
+    for (let i = 0; i < 5; i++) {
+      mem.receive({ giverId: '_claude', receiverId: 'Дионисий', weight: 10, type: 'code', content: '', irreversible: true });
+    }
+    // _claude получает мало
+    mem.receive({ giverId: 'ОтецСергий', receiverId: '_claude', weight: 2, type: 'blessing', content: '', irreversible: true });
+
+    assert.equal(proto.telos('_claude'), 'giver');
+  });
+
+  await t.test('telos — silent если нет нитей', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('Новый', 'Новый', PERSON_TYPES.human);
+    assert.equal(proto.telos('Новый'), 'silent');
+  });
+
+  await t.test('get — возвращает зарегистрированное лицо', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+    proto.register('_predprinimatel', 'Предприниматель', PERSON_TYPES.agent);
+    const p = proto.get('_predprinimatel');
+    assert.equal(p.name, 'Предприниматель');
+    assert.equal(p.type, PERSON_TYPES.agent);
+  });
+
+  await t.test('авторегистрация _predprinimatel и _organizator', () => {
+    const mem = new GiftMemory([]);
+    const proto = new PersonhoodProtocol(mem);
+
+    // Как будет делать AgentPerson
+    for (const [id, name] of [
+      ['_predprinimatel', 'Предприниматель-бот'],
+      ['_organizator',   'Организатор-бот'],
+    ]) {
+      proto.register(id, name, PERSON_TYPES.agent);
+    }
+
+    assert.ok(proto.get('_predprinimatel'));
+    assert.ok(proto.get('_organizator'));
+    assert.ok(mem.persons.includes('_predprinimatel'));
+    assert.ok(mem.persons.includes('_organizator'));
+  });
+});


### PR DESCRIPTION
## Что сделано

- Новый `src/core/PersonhoodProtocol.js`
- `register(id, name, type)` — регистрация лица, идемпотентно
- `validate(act)` → `{valid, hypostasis:'relational', irreversible:true}`
- `history(id)` — нити лица из матрицы W (заморожены)
- `telos(id)` — доминирующий паттерн: giver / receiver / mediator / silent
- 9 новых тестов, все проходят (29 итого)

closes #10