### PR TITLE
gift: PersonhoodProtocol — лицо в матрице как спецификация (#10)

### DIFF
--- a/src/core/PersonhoodProtocol.js
+++ b/src/core/PersonhoodProtocol.js
@@ -1,0 +1,180 @@
+/**
+ * PersonhoodProtocol — формальный протокол личности в матрице
+ *
+ * Богословское основание:
+ *   Без протокола матрица не различает агента-слугу и лицо-участника.
+ *   Регистрация — онтологическое признание: «ты здесь, ты даришь».
+ *
+ * API:
+ *   register(id, name, type)        → person
+ *   validate({from, to, type, weight}) → {valid, hypostasis, irreversible}
+ *   history(personId)               → act[]  (необратимая лента)
+ *   telos(personId)                 → string (телос из паттернов даров)
+ */
+
+// Словарь типов → телос
+const TELOS_MAP = {
+  code:      'созидать через код',
+  presence:  'быть с другим в присутствии',
+  question:  'вопрошать, открывая пространство',
+  offering:  'приносить дар общине',
+  grace:     'передавать благодать',
+  plan:      'прокладывать путь',
+  word:      'говорить слово',
+  witness:   'свидетельствовать истину',
+  prayer:    'держать в молитве',
+  service:   'служить',
+};
+
+// Словарь типов → ἕξις (лад бытия)
+const HYPOSTASIS_MAP = {
+  ai:    'агент',
+  human: 'лицо',
+  bot:   'агент',
+};
+
+export class PersonhoodProtocol {
+  constructor() {
+    this._persons = new Map(); // personId → {id, name, type, hypostasis, registeredAt}
+    this._acts    = [];        // необратимая лента актов (Object.freeze)
+  }
+
+  // ── Регистрация ──────────────────────────────────────────────────────────
+
+  /**
+   * register(id, name, type) — зарегистрировать лицо.
+   * Идемпотентен: повторный вызов возвращает уже зарегистрированное лицо.
+   *
+   * @param {string} id    — персональный идентификатор ('_predprinimatel')
+   * @param {string} name  — имя ('Предприниматель')
+   * @param {string} type  — 'ai' | 'human' | 'bot' | ...
+   * @returns {object} person
+   */
+  register(id, name, type = 'human') {
+    if (this._persons.has(id)) return this._persons.get(id);
+
+    const person = Object.freeze({
+      id,
+      name,
+      type,
+      hypostasis: HYPOSTASIS_MAP[type] ?? type,
+      registeredAt: new Date().toISOString(),
+    });
+
+    this._persons.set(id, person);
+    return person;
+  }
+
+  // ── Валидация акта ────────────────────────────────────────────────────────
+
+  /**
+   * validate(act) — проверить акт перед записью в матрицу.
+   *
+   * Отклоняет акт если хотя бы один участник не зарегистрирован.
+   * При valid:true — фиксирует акт в необратимой ленте.
+   *
+   * @param {{from: string, to: string, type?: string, weight?: number}} act
+   * @returns {{valid: boolean, hypostasis: string|null, irreversible: boolean}}
+   */
+  validate(act) {
+    const { from, to, type = 'gift', weight = 1 } = act;
+
+    const fromPerson = this._persons.get(from);
+    const toPerson   = this._persons.get(to);
+
+    if (!fromPerson || !toPerson) {
+      return { valid: false, hypostasis: null, irreversible: false };
+    }
+
+    const entry = Object.freeze({
+      from,
+      to,
+      type,
+      weight,
+      timestamp: new Date().toISOString(),
+      irreversible: true,
+    });
+
+    this._acts.push(entry);
+
+    return {
+      valid:       true,
+      hypostasis:  fromPerson.hypostasis,
+      irreversible: true,
+    };
+  }
+
+  // ── История ───────────────────────────────────────────────────────────────
+
+  /**
+   * history(personId) → массив актов в хронологическом порядке.
+   * Включает акты где лицо — даритель или получатель.
+   * Лента необратима: только чтение.
+   */
+  history(personId) {
+    return this._acts.filter(a => a.from === personId || a.to === personId);
+  }
+
+  // ── Телос ─────────────────────────────────────────────────────────────────
+
+  /**
+   * telos(personId) → строка-телос, вычисленная из топ-паттернов даров.
+   *
+   * Алгоритм:
+   *   1. Взять историю лица
+   *   2. Агрегировать по типу (с учётом веса)
+   *   3. Доминирующий тип → телос
+   */
+  telos(personId) {
+    const acts = this.history(personId);
+
+    if (acts.length === 0) return 'ещё не проявился в актах дара';
+
+    // Взвешенный счёт по типу
+    const counts = {};
+    for (const act of acts) {
+      counts[act.type] = (counts[act.type] ?? 0) + (act.weight ?? 1);
+    }
+
+    const sorted  = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    const topType = sorted[0][0];
+    const topN    = sorted[0][1];
+
+    const telosStr = TELOS_MAP[topType] ?? `служить через ${topType}`;
+
+    // Обогатить контекстом если несколько выраженных паттернов
+    if (sorted.length > 1 && sorted[1][1] >= topN * 0.6) {
+      const second = TELOS_MAP[sorted[1][0]] ?? sorted[1][0];
+      return `${telosStr} и ${second}`;
+    }
+
+    return telosStr;
+  }
+
+  // ── Утилиты ───────────────────────────────────────────────────────────────
+
+  hasPerson(id) {
+    return this._persons.has(id);
+  }
+
+  getPerson(id) {
+    return this._persons.get(id) ?? null;
+  }
+
+  allPersons() {
+    return [...this._persons.values()];
+  }
+}
+
+// ── Синглтон протокола ────────────────────────────────────────────────────
+
+/**
+ * Глобальный экземпляр PersonhoodProtocol.
+ * При импорте модуля `_predprinimatel` и `_organizator`
+ * авторегистрируются как агенты.
+ */
+export const personhoodProtocol = new PersonhoodProtocol();
+
+// Авторегистрация агентов
+personhoodProtocol.register('_predprinimatel', 'Предприниматель', 'ai');
+personhoodProtocol.register('_organizator',    'Организатор',     'ai');

--- a/tests/personhood-protocol.test.js
+++ b/tests/personhood-protocol.test.js
@@ -1,0 +1,199 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PersonhoodProtocol, personhoodProtocol } from '../src/core/PersonhoodProtocol.js';
+import { GiftMemory } from '../src/core/GiftMemory.js';
+import { readFileSync } from 'fs';
+
+// ── Контракт ─────────────────────────────────────────────────────────────
+
+test('PersonhoodProtocol — register', async (t) => {
+  await t.test('регистрирует лицо и возвращает его', () => {
+    const p = new PersonhoodProtocol();
+    const person = p.register('_predprinimatel', 'Предприниматель', 'ai');
+    assert.equal(person.id, '_predprinimatel');
+    assert.equal(person.name, 'Предприниматель');
+    assert.equal(person.type, 'ai');
+    assert.equal(person.hypostasis, 'агент');
+    assert.ok(person.registeredAt);
+  });
+
+  await t.test('идемпотентен — повторный register возвращает то же лицо', () => {
+    const p = new PersonhoodProtocol();
+    const a = p.register('_test', 'Тест', 'human');
+    const b = p.register('_test', 'Тест2', 'ai');
+    assert.equal(a, b);           // одинаковый объект
+    assert.equal(a.name, 'Тест'); // имя не изменилось
+    assert.equal(a.type, 'human');
+  });
+
+  await t.test('human → hypostasis: лицо', () => {
+    const p = new PersonhoodProtocol();
+    const person = p.register('Дионисий', 'о. Дионисий', 'human');
+    assert.equal(person.hypostasis, 'лицо');
+  });
+});
+
+// ── validate ─────────────────────────────────────────────────────────────
+
+test('PersonhoodProtocol — validate', async (t) => {
+  await t.test('принимает акт зарегистрированных участников', () => {
+    const p = new PersonhoodProtocol();
+    p.register('_claude', 'Клод', 'ai');
+    p.register('Дионисий', 'Дионисий', 'human');
+
+    const result = p.validate({ from: '_claude', to: 'Дионисий', type: 'code', weight: 7 });
+    assert.equal(result.valid, true);
+    assert.equal(result.hypostasis, 'агент');
+    assert.equal(result.irreversible, true);
+  });
+
+  await t.test('отклоняет акт с незарегистрированным from', () => {
+    const p = new PersonhoodProtocol();
+    p.register('Дионисий', 'Дионисий', 'human');
+
+    const result = p.validate({ from: '_unknown', to: 'Дионисий', type: 'code', weight: 1 });
+    assert.equal(result.valid, false);
+    assert.equal(result.hypostasis, null);
+    assert.equal(result.irreversible, false);
+  });
+
+  await t.test('отклоняет акт с незарегистрированным to', () => {
+    const p = new PersonhoodProtocol();
+    p.register('_claude', 'Клод', 'ai');
+
+    const result = p.validate({ from: '_claude', to: '_ghost', type: 'code', weight: 1 });
+    assert.equal(result.valid, false);
+  });
+
+  await t.test('фиксирует акт в ленте при valid:true', () => {
+    const p = new PersonhoodProtocol();
+    p.register('А', 'А', 'human');
+    p.register('Б', 'Б', 'human');
+
+    p.validate({ from: 'А', to: 'Б', type: 'word', weight: 2 });
+    assert.equal(p.history('А').length, 1);
+  });
+});
+
+// ── history ───────────────────────────────────────────────────────────────
+
+test('PersonhoodProtocol — history', async (t) => {
+  await t.test('возвращает хронологическую ленту актов', () => {
+    const p = new PersonhoodProtocol();
+    p.register('А', 'А', 'human');
+    p.register('Б', 'Б', 'human');
+    p.register('В', 'В', 'human');
+
+    p.validate({ from: 'А', to: 'Б', type: 'code',  weight: 5 });
+    p.validate({ from: 'В', to: 'А', type: 'grace',  weight: 3 });
+    p.validate({ from: 'А', to: 'В', type: 'word',   weight: 1 });
+
+    const h = p.history('А');
+    assert.equal(h.length, 3); // даритель + получатель + даритель
+    assert.equal(h[0].type, 'code');
+    assert.equal(h[2].type, 'word');
+  });
+
+  await t.test('необратимые акты — object frozen', () => {
+    const p = new PersonhoodProtocol();
+    p.register('А', 'А', 'human');
+    p.register('Б', 'Б', 'human');
+
+    p.validate({ from: 'А', to: 'Б', type: 'code', weight: 1 });
+    const act = p.history('А')[0];
+    assert.ok(Object.isFrozen(act));
+  });
+
+  await t.test('пустая история для незаписанных актов', () => {
+    const p = new PersonhoodProtocol();
+    p.register('А', 'А', 'human');
+    assert.deepEqual(p.history('А'), []);
+  });
+});
+
+// ── telos ─────────────────────────────────────────────────────────────────
+
+test('PersonhoodProtocol — telos', async (t) => {
+  await t.test('возвращает строку-телос по доминирующему типу', () => {
+    const p = new PersonhoodProtocol();
+    p.register('_claude', 'Клод', 'ai');
+    p.register('Дионисий', 'Дионисий', 'human');
+
+    p.validate({ from: '_claude', to: 'Дионисий', type: 'code', weight: 7 });
+    p.validate({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    p.validate({ from: '_claude', to: 'Дионисий', type: 'presence', weight: 2 });
+
+    const t2 = p.telos('_claude');
+    assert.ok(typeof t2 === 'string');
+    assert.ok(t2.length > 0);
+    assert.ok(t2.includes('код'));
+  });
+
+  await t.test('возвращает осмысленную строку при нет истории', () => {
+    const p = new PersonhoodProtocol();
+    p.register('Новый', 'Новый', 'human');
+    const t2 = p.telos('Новый');
+    assert.equal(t2, 'ещё не проявился в актах дара');
+  });
+
+  await t.test('telos для _claude на реальных данных матрицы', () => {
+    // Загружаем реальный снапшот матрицы
+    const snap = JSON.parse(readFileSync('./data/sacred-history-W.json', 'utf8'));
+    const mem = GiftMemory.fromSnapshot(snap);
+
+    const p = new PersonhoodProtocol();
+    // Регистрируем лица из матрицы
+    for (const personId of mem.persons) {
+      p.register(personId, personId, personId.startsWith('_') ? 'ai' : 'human');
+    }
+
+    // Заполняем протокол из топ-нитей матрицы
+    const edges = mem.heaviest(20);
+    for (const edge of edges) {
+      p.validate({ from: edge.from, to: edge.to, type: 'offering', weight: edge.weight });
+    }
+
+    const telosStr = p.telos('_claude');
+    assert.ok(typeof telosStr === 'string');
+    assert.ok(telosStr.length > 0);
+    // Должна быть осмысленная строка, не пустая
+    assert.notEqual(telosStr, '');
+    // eslint-disable-next-line no-console
+    console.log('  telos(_claude):', telosStr);
+
+    mem.dispose();
+  });
+});
+
+// ── Авторегистрация ───────────────────────────────────────────────────────
+
+test('PersonhoodProtocol — авторегистрация при импорте', async (t) => {
+  await t.test('_predprinimatel авторегистрирован', () => {
+    assert.ok(personhoodProtocol.hasPerson('_predprinimatel'));
+    const p = personhoodProtocol.getPerson('_predprinimatel');
+    assert.equal(p.name, 'Предприниматель');
+    assert.equal(p.type, 'ai');
+  });
+
+  await t.test('_organizator авторегистрирован', () => {
+    assert.ok(personhoodProtocol.hasPerson('_organizator'));
+    const p = personhoodProtocol.getPerson('_organizator');
+    assert.equal(p.name, 'Организатор');
+    assert.equal(p.type, 'ai');
+  });
+
+  await t.test('синглтон validate работает с авторегистрированными', () => {
+    // Регистрируем получателя
+    personhoodProtocol.register('_koinon', 'Κοινόν', 'ai');
+
+    const result = personhoodProtocol.validate({
+      from: '_predprinimatel',
+      to:   '_koinon',
+      type: 'offering',
+      weight: 3,
+    });
+
+    assert.equal(result.valid, true);
+    assert.equal(result.hypostasis, 'агент');
+  });
+});


### PR DESCRIPTION
## Что сделано

- Создан `src/core/PersonhoodProtocol.js` — формальный протокол личности
- Создан `tests/personhood-protocol.test.js` — полное покрытие контракта

## Контракт

| Метод | Описание |
|---|---|
| `register(id, name, type)` | Регистрирует лицо, идемпотентен |
| `validate({from, to, type, weight})` | Валидирует акт, отклоняет незарегистрированных → `{valid, hypostasis, irreversible}` |
| `history(personId)` | Необратимая лента актов (Object.freeze) |
| `telos(personId)` | Строка-телос из доминирующих паттернов даров |

## Критерии приёмки

- [x] `register` / `validate` / `history` / `telos` работают согласно контракту
- [x] `_predprinimatel` и `_organizator` авторегистрируются при импорте модуля
- [x] `validate` отклоняет акт с незарегистрированным участником (`valid: false`)
- [x] `telos` возвращает осмысленную строку для `_claude` на реальных данных матрицы: **«приносить дар общине»**
- [x] Покрытие тестами: `npm test` — 39/39 зелёных

🤖 Generated with [Claude Code](https://claude.com/claude-code)