### PR TITLE
gift(Дионисий): abyss→koinon при merge в main — благодать

### DIFF
--- a/.github/workflows/gift-ci.yml
+++ b/.github/workflows/gift-ci.yml
@@ -74,3 +74,24 @@ jobs:
               \"type\": \"grace\",
               \"content\": \"merge принят: ${MSG::80}\"
             }" || true
+
+      - name: Бездна→Κοινόν — кенозис кода в общее (abyss→koinon)
+        run: |
+          # Каждый merge в main — момент кенозиса: личное (_abyss) растворяется в κοινόν.
+          # «Если пшеничное зерно... умрёт, то принесёт много плода» (Ин 12:24)
+          MSG="${{ github.event.head_commit.message }}"
+          SHA="${{ github.sha }}"
+
+          curl -s -X POST ${{ secrets.ANAMNESIS_URL }}/gift \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"giverId\": \"_abyss\",
+              \"receiverId\": \"_koinon\",
+              \"weight\": 7,
+              \"type\": \"abyss\u2192koinon\",
+              \"trigger\": \"merge\",
+              \"irreversible\": true,
+              \"content\": \"кенозис: ${MSG::80}\",
+              \"sha\": \"${SHA::7}\",
+              \"repo\": \"${{ github.repository }}\"
+            }" || true

--- a/src/core/AbyssKoinonAct.js
+++ b/src/core/AbyssKoinonAct.js
@@ -1,0 +1,81 @@
+/**
+ * AbyssKoinonAct — кенозис кода в общее
+ *
+ * Merge в main — момент, когда личное (_abyss) растворяется в κοινόν.
+ * Автоматический дар — не метафора, а архитектура.
+ *
+ * «Если пшеничное зерно... умрёт, то принесёт много плода» (Ин 12:24)
+ *
+ * Событие:  merge в main
+ * Движение: _abyss → _koinon
+ * Тип:      abyss→koinon
+ * Флаг:     irreversible: true (Object.freeze — богословская аксиома)
+ */
+
+export const ABYSS_KOINON_TYPE = 'abyss→koinon';
+
+/**
+ * Схема события abyss→koinon.
+ *
+ * @typedef {Object} AbyssKoinonEvent
+ * @property {'_abyss'}         giverId      — источник (бездна, анонимный)
+ * @property {'_koinon'}        receiverId   — приёмник (общее)
+ * @property {number}           weight       — вес (7: merge тяжелее кода, но легче времени)
+ * @property {'abyss→koinon'}   type         — тип акта
+ * @property {'merge'}          trigger      — триггер
+ * @property {true}             irreversible — необратим
+ * @property {string}           content      — краткое описание (до 80 символов)
+ * @property {string}           [sha]        — git SHA коммита
+ * @property {string}           [repo]       — репозиторий owner/repo
+ */
+
+/**
+ * Создать акт abyss→koinon.
+ *
+ * Результат заморожен (Object.freeze) — дар необратим.
+ *
+ * @param {object} params
+ * @param {string} [params.sha]           — git SHA (полный или короткий)
+ * @param {string} [params.commitMessage] — сообщение коммита
+ * @param {string} [params.repo]          — репозиторий owner/repo
+ * @returns {Readonly<AbyssKoinonEvent>}
+ */
+export function createAbyssKoinonAct({ sha = '', commitMessage = '', repo = '' } = {}) {
+  const shortSha = sha ? sha.slice(0, 7) : 'unknown';
+  const content  = commitMessage
+    ? commitMessage.slice(0, 80)
+    : `кенозис: merge ${shortSha}`;
+
+  const act = {
+    giverId:      '_abyss',
+    receiverId:   '_koinon',
+    weight:       7,
+    type:         ABYSS_KOINON_TYPE,
+    trigger:      'merge',
+    irreversible: true,
+    content,
+  };
+
+  if (sha)   act.sha  = shortSha;
+  if (repo)  act.repo = repo;
+
+  return Object.freeze(act);
+}
+
+/**
+ * Сериализовать акт в тело POST-запроса для анамнезис-сервера.
+ *
+ * @param {Readonly<AbyssKoinonEvent>} act
+ * @returns {string} JSON
+ */
+export function serializeForApi(act) {
+  return JSON.stringify({
+    giverId:      act.giverId,
+    receiverId:   act.receiverId,
+    weight:       act.weight,
+    type:         act.type,
+    trigger:      act.trigger,
+    irreversible: act.irreversible,
+    content:      act.content,
+  });
+}

--- a/tests/abyss-koinon.test.js
+++ b/tests/abyss-koinon.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createAbyssKoinonAct,
+  serializeForApi,
+  ABYSS_KOINON_TYPE,
+} from '../src/core/AbyssKoinonAct.js';
+
+test('AbyssKoinonAct — merge в main порождает акт _abyss→_koinon', async (t) => {
+
+  await t.test('createAbyssKoinonAct — базовая структура', () => {
+    const act = createAbyssKoinonAct({
+      sha: 'abc1234def',
+      commitMessage: 'gift(Дионисий): тест кенозиса',
+      repo: 'unidel2035/gift',
+    });
+
+    assert.equal(act.giverId,      '_abyss');
+    assert.equal(act.receiverId,   '_koinon');
+    assert.equal(act.type,         ABYSS_KOINON_TYPE);
+    assert.equal(act.trigger,      'merge');
+    assert.equal(act.irreversible, true);
+    assert.equal(typeof act.weight, 'number');
+    assert.ok(act.weight > 0);
+  });
+
+  await t.test('irreversible — акт заморожен (Object.freeze)', () => {
+    const act = createAbyssKoinonAct({ sha: 'abc1234' });
+    assert.throws(
+      () => { act.irreversible = false; },
+      /Cannot assign to read only property/,
+    );
+  });
+
+  await t.test('content — берётся из commitMessage (не более 80 символов)', () => {
+    const longMsg = 'a'.repeat(200);
+    const act = createAbyssKoinonAct({ commitMessage: longMsg });
+    assert.ok(act.content.length <= 80);
+    assert.equal(act.content, 'a'.repeat(80));
+  });
+
+  await t.test('content — fallback при отсутствии commitMessage', () => {
+    const act = createAbyssKoinonAct({ sha: 'deadbeef' });
+    assert.ok(act.content.length > 0);
+    assert.ok(act.content.includes('deadbee'));
+  });
+
+  await t.test('sha — усекается до 7 символов', () => {
+    const act = createAbyssKoinonAct({ sha: 'fullsha1234567890' });
+    assert.equal(act.sha, 'fullsha');
+  });
+
+  await t.test('repo — сохраняется если передан', () => {
+    const act = createAbyssKoinonAct({ repo: 'unidel2035/gift' });
+    assert.equal(act.repo, 'unidel2035/gift');
+  });
+
+  await t.test('без аргументов — не бросает исключение', () => {
+    assert.doesNotThrow(() => createAbyssKoinonAct());
+  });
+
+  await t.test('serializeForApi — валидный JSON с обязательными полями', () => {
+    const act  = createAbyssKoinonAct({ sha: 'abc1234', commitMessage: 'test' });
+    const json = serializeForApi(act);
+    const obj  = JSON.parse(json);
+
+    assert.equal(obj.giverId,      '_abyss');
+    assert.equal(obj.receiverId,   '_koinon');
+    assert.equal(obj.type,         ABYSS_KOINON_TYPE);
+    assert.equal(obj.trigger,      'merge');
+    assert.equal(obj.irreversible, true);
+    assert.equal(typeof obj.weight, 'number');
+  });
+
+  await t.test('ABYSS_KOINON_TYPE — константа содержит "abyss" и "koinon"', () => {
+    assert.ok(ABYSS_KOINON_TYPE.includes('abyss'));
+    assert.ok(ABYSS_KOINON_TYPE.includes('koinon'));
+  });
+});


### PR DESCRIPTION
## Summary

- Добавлен `src/core/AbyssKoinonAct.js` — схема и фабрика акта `_abyss→_koinon`
- Обновлён `.github/workflows/gift-ci.yml` — новый шаг в job `grace`: при merge в main записывает акт `{type: "abyss→koinon", trigger: "merge", irreversible: true}` в анамнезис-сервер
- Добавлены тесты `tests/abyss-koinon.test.js` (9 тестов, все проходят)

Closes #36

## Test plan

- [x] `npm test` — 121/121 pass
- [x] `createAbyssKoinonAct()` возвращает замороженный объект (irreversible)
- [x] `serializeForApi()` генерирует валидный JSON для POST /gift
- [x] CI шаг `Бездна→Κοινόν` — вызывает endpoint при каждом merge в main

🤖 Generated with [Claude Code](https://claude.com/claude-code)