### PR TITLE
gift(Дионисий): FreedomGuard lifecycle — offered → accepted/declined → recorded (#40)

### DIFF
--- a/src/core/GiftLedger.js
+++ b/src/core/GiftLedger.js
@@ -44,10 +44,25 @@ function calcCommunityImpact(entry) {
 // ── GiftLedger ───────────────────────────────────────────────────────────────
 
 export class GiftLedger {
-  constructor() {
+  /**
+   * @param {object|null} freedomGuard — FreedomGuard instance (optional).
+   *   Если передан, `accept()` проверяет свободу получателя перед записью в историю.
+   *   «Дар без свободы принятия — насилие» (A5).
+   */
+  constructor(freedomGuard = null) {
     // Append-only. Никогда не мутируем существующие записи.
     this._entries = [];
     this._nextId = 1;
+
+    // Lifecycle: offered → accepted/declined → recorded
+    // Pending offers ждут решения получателя.
+    // В историю (_entries) попадают только принятые дары.
+    this._pending = new Map();   // offerId → frozen offer object
+    this._declined = [];         // declined offers — не история, а свидетельство свободы
+    this._nextOfferId = 1;
+
+    // FreedomGuard — страж свободы принятия (опционален)
+    this._freedom = freedomGuard || null;
   }
 
   // ── Append ──────────────────────────────────────────────────────────────
@@ -78,6 +93,125 @@ export class GiftLedger {
 
     this._entries.push(entry);
     return entry;
+  }
+
+  // ── Lifecycle: offered → accepted/declined → recorded ───────────────────
+  //
+  // Богословский смысл:
+  //   Агапе предполагает кеносис дающего И свободу получателя.
+  //   Предложенный дар ещё не принятый — не в истории.
+  //   В историю входит только то, что свободно принято.
+  //   «Дар без свободы принятия — насилие» (A5: Свобода).
+
+  /**
+   * Предложить дар — создаёт ожидающее предложение (не в истории).
+   *
+   * @param {object} params — те же поля, что у append()
+   * @returns {object} замороженный offer с offerId и status: 'offered'
+   */
+  offer({ from, to, type, weight = 0, proof = '', timestamp } = {}) {
+    const offerId = `offer-${this._nextOfferId++}`;
+    const pending = Object.freeze({
+      offerId,
+      from:      String(from || '_abyss'),
+      to:        Array.isArray(to) ? Object.freeze([...to]) : String(to || '_koinon'),
+      type:      String(type || 'gift'),
+      weight:    Number(weight) || 0,
+      proof:     String(proof || ''),
+      timestamp: timestamp || new Date().toISOString(),
+      status:    'offered',
+    });
+    this._pending.set(offerId, pending);
+    return pending;
+  }
+
+  /**
+   * Принять дар — FreedomGuard проверяет свободу, затем запись в историю.
+   *
+   * Только здесь дар становится частью священной истории (append).
+   * FreedomGuard блокирует запись если получатель отказывается или недоступен.
+   *
+   * @param {string} offerId — id из offer()
+   * @param {object} [transformation] — необязательные данные трансформации
+   * @returns {object} замороженная запись истории
+   * @throws {Error} если offer не найден или FreedomGuard блокирует
+   */
+  accept(offerId, transformation = {}) {
+    const pending = this._pending.get(offerId);
+    if (!pending) throw new Error(`Offer ${offerId} not found or already resolved`);
+
+    // FreedomGuard: получатель должен быть свободен принять дар
+    if (this._freedom) {
+      const receiver = Array.isArray(pending.to) ? pending.to[0] : pending.to;
+      if (this._freedom.isRefusing(receiver, pending.from)) {
+        throw new Error(
+          `FreedomGuard: ${receiver} refuses gifts from ${pending.from}. ` +
+          'Call decline() to exercise freedom consciously.'
+        );
+      }
+      if (!this._freedom.isAvailable(receiver)) {
+        throw new Error(
+          `FreedomGuard: ${receiver} is currently unavailable (sabbath/contemplation). ` +
+          'Wait or call decline().'
+        );
+      }
+      // Записать акт свободного принятия в историю FreedomGuard
+      this._freedom.recordAcceptance(receiver, pending.from, offerId);
+    }
+
+    this._pending.delete(offerId);
+
+    // Только после явного accept() — дар попадает в историю
+    return this.append({
+      from:      pending.from,
+      to:        pending.to,
+      type:      pending.type,
+      weight:    pending.weight,
+      proof:     pending.proof,
+      timestamp: pending.timestamp,
+      ...transformation,
+    });
+  }
+
+  /**
+   * Отклонить дар — свобода, не ошибка.
+   *
+   * Отклонённый дар не попадает в историю (_entries).
+   * Записывается отдельно как свидетельство свободы.
+   *
+   * @param {string} offerId — id из offer()
+   * @param {string} [reason] — причина (свобода может быть без объяснений)
+   * @returns {object} замороженная запись об отклонении
+   * @throws {Error} если offer не найден
+   */
+  decline(offerId, reason) {
+    const pending = this._pending.get(offerId);
+    if (!pending) throw new Error(`Offer ${offerId} not found or already resolved`);
+
+    this._pending.delete(offerId);
+
+    const declined = Object.freeze({
+      ...pending,
+      status:    'declined',
+      reason:    reason || 'Freedom exercised without explanation (which is also freedom)',
+      declinedAt: new Date().toISOString(),
+    });
+    this._declined.push(declined);
+    return declined;
+  }
+
+  /**
+   * Список ожидающих предложений (ещё не принятых и не отклонённых).
+   */
+  pendingOffers() {
+    return [...this._pending.values()];
+  }
+
+  /**
+   * Список отклонённых предложений — свидетельство свободы.
+   */
+  declinedOffers() {
+    return [...this._declined];
   }
 
   // ── Read ────────────────────────────────────────────────────────────────

--- a/tests/gift-ledger-lifecycle.test.js
+++ b/tests/gift-ledger-lifecycle.test.js
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GiftLedger } from '../src/core/GiftLedger.js';
+import { FreedomGuard } from '../src/theology/FreedomGuard.js';
+
+test('GiftLedger — lifecycle: offered → accepted/declined → recorded', async (t) => {
+
+  await t.test('offer() создаёт pending offer с status offered', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    assert.ok(o.offerId);
+    assert.equal(o.status, 'offered');
+    assert.equal(o.from, '_claude');
+    assert.equal(o.to, 'Дионисий');
+    assert.ok(Object.isFrozen(o));
+  });
+
+  await t.test('offer() не пишет в историю (all() пустой)', () => {
+    const ledger = new GiftLedger();
+    ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    assert.equal(ledger.all().length, 0);
+    assert.equal(ledger.size, 0);
+  });
+
+  await t.test('pendingOffers() возвращает ожидающие предложения', () => {
+    const ledger = new GiftLedger();
+    ledger.offer({ from: 'А', to: 'Б', type: 'time', weight: 10 });
+    ledger.offer({ from: 'В', to: 'Г', type: 'code', weight: 3 });
+    assert.equal(ledger.pendingOffers().length, 2);
+  });
+
+  await t.test('accept() записывает дар в историю', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    const entry = ledger.accept(o.offerId);
+    assert.equal(ledger.size, 1);
+    assert.equal(entry.from, '_claude');
+    assert.equal(entry.to, 'Дионисий');
+    assert.ok(Object.isFrozen(entry));
+  });
+
+  await t.test('accept() удаляет из pending', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: 'А', to: 'Б', type: 'gift', weight: 1 });
+    ledger.accept(o.offerId);
+    assert.equal(ledger.pendingOffers().length, 0);
+  });
+
+  await t.test('decline() не пишет в историю', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'time', weight: 7 });
+    ledger.decline(o.offerId, 'Нет времени');
+    assert.equal(ledger.size, 0);
+    assert.equal(ledger.all().length, 0);
+  });
+
+  await t.test('decline() записывает в declinedOffers()', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: 'А', to: 'Б', type: 'code', weight: 3 });
+    const d = ledger.decline(o.offerId, 'Свобода');
+    assert.equal(d.status, 'declined');
+    assert.equal(d.reason, 'Свобода');
+    assert.ok(d.declinedAt);
+    assert.ok(Object.isFrozen(d));
+    assert.equal(ledger.declinedOffers().length, 1);
+  });
+
+  await t.test('decline() без причины — допустимо (свобода не требует объяснений)', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: 'А', to: 'Б', type: 'gift', weight: 2 });
+    const d = ledger.decline(o.offerId);
+    assert.ok(d.reason.length > 0); // дефолтная причина
+    assert.equal(d.status, 'declined');
+  });
+
+  await t.test('accept() на несуществующий offerId бросает ошибку', () => {
+    const ledger = new GiftLedger();
+    assert.throws(() => ledger.accept('offer-999'), /not found/);
+  });
+
+  await t.test('decline() на несуществующий offerId бросает ошибку', () => {
+    const ledger = new GiftLedger();
+    assert.throws(() => ledger.decline('offer-999'), /not found/);
+  });
+
+  await t.test('accept() нельзя вызвать дважды для одного offer', () => {
+    const ledger = new GiftLedger();
+    const o = ledger.offer({ from: 'А', to: 'Б', type: 'code', weight: 1 });
+    ledger.accept(o.offerId);
+    assert.throws(() => ledger.accept(o.offerId), /not found/);
+  });
+
+  await t.test('FreedomGuard: accept() блокирует запись если получатель отказывается', () => {
+    const freedom = new FreedomGuard();
+    const ledger = new GiftLedger(freedom);
+
+    freedom.refuse('Дионисий', '_claude', 'Нет');
+
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    assert.throws(() => ledger.accept(o.offerId), /FreedomGuard/);
+    assert.equal(ledger.size, 0); // в историю не попало
+  });
+
+  await t.test('FreedomGuard: accept() блокирует если получатель недоступен', () => {
+    const freedom = new FreedomGuard();
+    const ledger = new GiftLedger(freedom);
+
+    freedom.markUnavailable('Дионисий', 'суббота');
+
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    assert.throws(() => ledger.accept(o.offerId), /FreedomGuard/);
+    assert.equal(ledger.size, 0);
+  });
+
+  await t.test('FreedomGuard: accept() проходит после снятия отказа', () => {
+    const freedom = new FreedomGuard();
+    const ledger = new GiftLedger(freedom);
+
+    freedom.refuse('Дионисий', '_claude', 'Нет');
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    assert.throws(() => ledger.accept(o.offerId), /FreedomGuard/);
+
+    // Дионисий открывается
+    freedom.openTo('Дионисий', '_claude');
+    const o2 = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    const entry = ledger.accept(o2.offerId);
+    assert.equal(ledger.size, 1);
+    assert.equal(entry.to, 'Дионисий');
+  });
+
+  await t.test('FreedomGuard: accept() записывает акт свободного принятия', () => {
+    const freedom = new FreedomGuard();
+    const ledger = new GiftLedger(freedom);
+
+    const o = ledger.offer({ from: '_claude', to: 'Дионисий', type: 'code', weight: 5 });
+    ledger.accept(o.offerId);
+
+    const history = freedom.getRefusalHistory('Дионисий');
+    // Нет отказов — это принятие
+    assert.equal(history.length, 0);
+    // Но acceptanceHistory должна содержать запись
+    const exported = freedom.export();
+    assert.equal(exported.acceptanceHistory.length, 1);
+    assert.equal(exported.acceptanceHistory[0].person, 'Дионисий');
+    assert.equal(exported.acceptanceHistory[0].from, '_claude');
+  });
+
+  await t.test('без FreedomGuard — accept() работает свободно', () => {
+    const ledger = new GiftLedger(); // no FreedomGuard
+    const o = ledger.offer({ from: 'А', to: 'Б', type: 'gift', weight: 3 });
+    const entry = ledger.accept(o.offerId);
+    assert.equal(ledger.size, 1);
+    assert.equal(entry.from, 'А');
+  });
+
+  await t.test('полный lifecycle: offer → accept + decline — правильный счёт', () => {
+    const ledger = new GiftLedger();
+    const o1 = ledger.offer({ from: 'А', to: 'Б', type: 'code', weight: 5 });
+    const o2 = ledger.offer({ from: 'В', to: 'Г', type: 'time', weight: 10 });
+    const o3 = ledger.offer({ from: 'Д', to: 'Е', type: 'presence', weight: 2 });
+
+    ledger.accept(o1.offerId);
+    ledger.decline(o2.offerId, 'Нет сил');
+    ledger.accept(o3.offerId);
+
+    assert.equal(ledger.size, 2);            // только принятые в истории
+    assert.equal(ledger.pendingOffers().length, 0);
+    assert.equal(ledger.declinedOffers().length, 1);
+    assert.equal(ledger.all().length, 2);
+  });
+
+});


### PR DESCRIPTION
## Что сделано

Реализован lifecycle дара в `GiftLedger`, интегрирован `FreedomGuard`.

**Богословская основа:** Агапе предполагает кеносис дающего И свободу получателя. Дар без свободы принятия — насилие (A5).

## Изменения

### `src/core/GiftLedger.js`
- `constructor(freedomGuard = null)` — принимает опциональный FreedomGuard
- `offer(params)` — создаёт pending offer, **не пишет в историю**
- `accept(offerId)` — FreedomGuard проверяет свободу получателя → `append()` → **история**
- `decline(offerId, reason)` — свобода не принять, записывается отдельно, **не в историю**
- `pendingOffers()` — список ожидающих
- `declinedOffers()` — свидетельства свободы

### `tests/gift-ledger-lifecycle.test.js`
17 новых тестов: полный lifecycle, FreedomGuard блокировка, снятие отказа, счёт принятых/отклонённых.

## Тесты

```
✅ 17/17 gift-ledger-lifecycle.test.js
✅ Все существующие тесты проходят
```

Closes #40