### PR TITLE
Заземление вердикта собора (рычаг лидеров BitGN, +22пп)

### DIFF
--- a/tests/sobor-grounding.test.js
+++ b/tests/sobor-grounding.test.js
@@ -1,0 +1,42 @@
+/**
+ * Заземление вердикта собора: находка без точной ссылки не считается.
+ * Рычаг лидеров BitGN (+22пп), наша анти-фиктивность. Детерминированно.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isGrounded, groundFindings, groundedVerdict } from '../utils/sobor-grounding.mjs';
+
+test('заземление вердикта', async (t) => {
+  await t.test('file:line — заземлено', () => {
+    assert.equal(isGrounded({ ref: 'src/a.js:42' }), true);
+    assert.equal(isGrounded({ file: 'cells/save.js:2' }), true);
+  });
+
+  await t.test('путь без строки заземлён только если реально открыт (touched)', () => {
+    assert.equal(isGrounded({ ref: '/proc/x.json' }), false);
+    assert.equal(isGrounded({ ref: '/proc/x.json' }, { touched: ['/proc/x.json'] }), true);
+  });
+
+  await t.test('нет ссылки — не заземлено', () => {
+    assert.equal(isGrounded({ why: 'звучит плохо' }), false);
+    assert.equal(isGrounded({ ref: '' }), false);
+  });
+
+  await t.test('groundFindings разделяет и даёт причину отброса', () => {
+    const { grounded, dropped } = groundFindings([
+      { why: 'a', ref: 'x.js:1' }, { why: 'b' },
+    ]);
+    assert.equal(grounded.length, 1);
+    assert.equal(dropped.length, 1);
+    assert.match(dropped[0].dropped_reason, /без акта не считается/);
+  });
+
+  await t.test('незаземлённое не влияет на вердикт', () => {
+    // только незаземлённые high → affirm (claims пустые)
+    assert.equal(groundedVerdict([{ severity: 'high', why: 'нет ссылки' }]).verdict, 'affirm');
+    // заземлённый high → reject
+    assert.equal(groundedVerdict([{ severity: 'high', ref: 'a.js:9' }]).verdict, 'reject');
+    // заземлённый med → open
+    assert.equal(groundedVerdict([{ severity: 'med', ref: 'a.js:9' }]).verdict, 'open');
+  });
+});

--- a/utils/sobor-grounding.mjs
+++ b/utils/sobor-grounding.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * sobor-grounding — заземление вердикта собора.
+ *
+ * Рычаг №1 победителей арены BitGN ECOM1 (подтверждён баллами): «нельзя процитировать
+ * файл, который ты не открывал». Победитель B одной правкой grounding-reference поднял
+ * 45→68% (+22пп). Балл берётся не оркестрацией, а ОТКАЗОМ принять незаземлённый ответ.
+ *
+ * Это наша же аксиома анти-фиктивности: claim без акта весит ноль. Здесь — в коде ревью:
+ * находка ревьюера/собора СЧИТАЕТСЯ только если она заземлена точной ссылкой —
+ * `файл:строка` ИЛИ путь, который ревьюер реально открывал (touched). Незаземлённые
+ * находки не отбрасываются молча, а помечаются `dropped` (видимы, но не влияют на вердикт).
+ *
+ * Совместимо: работает поверх находок sobor-blind-review / любого ревью.
+ *
+ * Запуск:  node utils/sobor-grounding.mjs --selftest
+ */
+
+// Точная ссылка: «path:line» (любой непробельный путь + двоеточие + номер строки).
+const REF_RE = /(^|[^\s:])[^\s:]*:\d+/;
+
+/** Заземлена ли находка: file:line, либо ref/file из реально открытых путей (touched). */
+export function isGrounded(finding, { touched = [] } = {}) {
+  const ref = String(finding.ref || finding.file || finding.path || '').trim();
+  if (!ref) return false;
+  if (REF_RE.test(ref)) return true;                 // file:line — самодостаточно
+  if (touched.includes(ref)) return true;            // путь, который реально читали
+  return false;
+}
+
+/** Разделить находки на заземлённые и отброшенные (с причиной). */
+export function groundFindings(findings = [], opts = {}) {
+  const grounded = [], dropped = [];
+  for (const f of findings) {
+    if (isGrounded(f, opts)) grounded.push(f);
+    else dropped.push({ ...f, dropped_reason: 'нет точной ссылки (file:line или открытый путь) — claim без акта не считается' });
+  }
+  return { grounded, dropped };
+}
+
+/**
+ * Вердикт по заземлённым находкам:
+ *   reject — есть заземлённая находка высокой важности;
+ *   open   — есть заземлённые находки (решает человек);
+ *   affirm — заземлённых находок нет.
+ * Незаземлённые НЕ влияют на вердикт (но возвращаются для прозрачности).
+ */
+export function groundedVerdict(findings = [], opts = {}) {
+  const { grounded, dropped } = groundFindings(findings, opts);
+  const verdict = grounded.some(f => f.severity === 'high') ? 'reject'
+    : grounded.length ? 'open' : 'affirm';
+  return { verdict, grounded, dropped, grounded_count: grounded.length, dropped_count: dropped.length };
+}
+
+// ── Самопроверка (детерминированная) ─────────────────────────────────
+if (import.meta.url === `file://${process.argv[1]}`) {
+  if (process.argv.includes('--selftest')) {
+    const findings = [
+      { severity: 'high', why: 'пустой catch', ref: 'cells/save.js:2' },        // заземлено (file:line)
+      { severity: 'med', why: 'не покрыт null', file: '/proc/x.json' },          // заземлено если touched
+      { severity: 'high', why: 'звучит плохо' },                                  // НЕ заземлено (нет ссылки)
+    ];
+    const r = groundedVerdict(findings, { touched: ['/proc/x.json'] });
+    console.log('вердикт:', r.verdict, '| заземлено:', r.grounded_count, '| отброшено:', r.dropped_count);
+    r.dropped.forEach(f => console.log('  ✗ отброшено:', f.why));
+    // ожидаем: 2 заземлены (одна high → reject), 1 отброшена
+    const ok = r.verdict === 'reject' && r.grounded_count === 2 && r.dropped_count === 1
+      && r.dropped[0].why === 'звучит плохо';
+    console.log(ok ? '\n✓ selftest passed (незаземлённое не влияет на вердикт)' : '\n✗ FAILED');
+    process.exit(ok ? 0 : 1);
+  }
+  console.log('node utils/sobor-grounding.mjs --selftest');
+}


### PR DESCRIPTION
## Что
`utils/sobor-grounding.mjs` — вердикт ревью/собора считает находку только если она **заземлена** точной ссылкой: `файл:строка` ИЛИ путь, реально открытый ревьюером. Незаземлённые находки не отбрасываются молча — помечаются `dropped` (видимы, но не влияют на вердикт). +6 тестов, selftest зелёный.

## Обоснование (зачем)
На боевой арене ИИ-агентов **BitGN ECOM1** мы реверс-инженерили архитектуры победителей. Их рычаг №1, подтверждённый баллами:

> «Балл берётся не умной оркестрацией, а **отказом сдать ответ, который не заземлён**».
> Победитель-B одной правкой grounding-reference поднял **45.4% → 67.8% (+22пп)** — больше, чем любой апгрейд модели. Принцип: «нельзя процитировать файл, который ты не открывал».

Это дословно **наша аксиома анти-фиктивности**: claim без акта весит ноль; нельзя отчитаться пустотой. Здесь она вшита в код ревью — собор/ревьюер не может «звучать убедительно» без точной ссылки на реальное место.

Источник уроков: `data/ecom1-baseline.json`, реверс победных архитектур ECOM1 (cited-sandbox, tuned-hermes).

## Эффект
- Собор перестаёт верить агенту на слово: каждая находка — с `файл:строка` или открытым путём, иначе не в счёт.
- Дисциплина важнее способности (урок лидеров) — теперь enforced, а не на доброй воле.

🤖 Generated with [Claude Code](https://claude.com/claude-code)